### PR TITLE
chore: init CocoaPods, install Alamofire

### DIFF
--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		41BDFE0728CA164C00017768 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 41BDFE0628CA164C00017768 /* Assets.xcassets */; };
 		41BDFE0A28CA164C00017768 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 41BDFE0828CA164C00017768 /* LaunchScreen.storyboard */; };
 		41BDFE1528CA164C00017768 /* DataLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE1428CA164C00017768 /* DataLayerTests.swift */; };
+		43191D82CA1EF59A6928AE46 /* Pods_DataLayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAFC0BFF785D8CB01827DF2D /* Pods_DataLayer.framework */; };
+		87D9684BF2F6FAA3DCB0E25D /* Pods_DataLayerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFB777B2EB545EBF1F9C23FF /* Pods_DataLayerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,6 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		07A8E7444B5E1F8C2BF9FC4D /* Pods-DataLayer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayer.debug.xcconfig"; path = "Target Support Files/Pods-DataLayer/Pods-DataLayer.debug.xcconfig"; sourceTree = "<group>"; };
 		41BDFDFA28CA164B00017768 /* DataLayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DataLayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFDFD28CA164B00017768 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		41BDFDFF28CA164B00017768 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -37,6 +40,11 @@
 		41BDFE0B28CA164C00017768 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		41BDFE1028CA164C00017768 /* DataLayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DataLayerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFE1428CA164C00017768 /* DataLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataLayerTests.swift; sourceTree = "<group>"; };
+		DAFC0BFF785D8CB01827DF2D /* Pods_DataLayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DataLayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC0146D3161118FC38243A4C /* Pods-DataLayerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayerTests.release.xcconfig"; path = "Target Support Files/Pods-DataLayerTests/Pods-DataLayerTests.release.xcconfig"; sourceTree = "<group>"; };
+		E6AC935ED0A6074A91D38FA6 /* Pods-DataLayerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayerTests.debug.xcconfig"; path = "Target Support Files/Pods-DataLayerTests/Pods-DataLayerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		E7BF9D2D8C67C23A44C52F4C /* Pods-DataLayer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayer.release.xcconfig"; path = "Target Support Files/Pods-DataLayer/Pods-DataLayer.release.xcconfig"; sourceTree = "<group>"; };
+		FFB777B2EB545EBF1F9C23FF /* Pods_DataLayerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DataLayerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -44,6 +52,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43191D82CA1EF59A6928AE46 /* Pods_DataLayer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -51,6 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				87D9684BF2F6FAA3DCB0E25D /* Pods_DataLayerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,6 +73,8 @@
 				41BDFDFC28CA164B00017768 /* DataLayer */,
 				41BDFE1328CA164C00017768 /* DataLayerTests */,
 				41BDFDFB28CA164B00017768 /* Products */,
+				CFBA6D8FEEEE6DBB48B3F3DF /* Pods */,
+				C4984F65CCE3AD7EAADE4BDD /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -97,6 +109,27 @@
 			path = DataLayerTests;
 			sourceTree = "<group>";
 		};
+		C4984F65CCE3AD7EAADE4BDD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DAFC0BFF785D8CB01827DF2D /* Pods_DataLayer.framework */,
+				FFB777B2EB545EBF1F9C23FF /* Pods_DataLayerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CFBA6D8FEEEE6DBB48B3F3DF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				07A8E7444B5E1F8C2BF9FC4D /* Pods-DataLayer.debug.xcconfig */,
+				E7BF9D2D8C67C23A44C52F4C /* Pods-DataLayer.release.xcconfig */,
+				E6AC935ED0A6074A91D38FA6 /* Pods-DataLayerTests.debug.xcconfig */,
+				DC0146D3161118FC38243A4C /* Pods-DataLayerTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -104,9 +137,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 41BDFE2428CA164C00017768 /* Build configuration list for PBXNativeTarget "DataLayer" */;
 			buildPhases = (
+				3EAF0197D67E152AACDAA82B /* [CP] Check Pods Manifest.lock */,
 				41BDFDF628CA164B00017768 /* Sources */,
 				41BDFDF728CA164B00017768 /* Frameworks */,
 				41BDFDF828CA164B00017768 /* Resources */,
+				00C1C4DE0C7454E792C68079 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -121,6 +156,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 41BDFE2728CA164C00017768 /* Build configuration list for PBXNativeTarget "DataLayerTests" */;
 			buildPhases = (
+				B3477FF20C35ED5A9AE82A23 /* [CP] Check Pods Manifest.lock */,
 				41BDFE0C28CA164C00017768 /* Sources */,
 				41BDFE0D28CA164C00017768 /* Frameworks */,
 				41BDFE0E28CA164C00017768 /* Resources */,
@@ -192,6 +228,70 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00C1C4DE0C7454E792C68079 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-DataLayer/Pods-DataLayer-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-DataLayer/Pods-DataLayer-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DataLayer/Pods-DataLayer-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3EAF0197D67E152AACDAA82B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DataLayer-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B3477FF20C35ED5A9AE82A23 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DataLayerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		41BDFDF628CA164B00017768 /* Sources */ = {
@@ -358,6 +458,7 @@
 		};
 		41BDFE2528CA164C00017768 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 07A8E7444B5E1F8C2BF9FC4D /* Pods-DataLayer.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -385,6 +486,7 @@
 		};
 		41BDFE2628CA164C00017768 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E7BF9D2D8C67C23A44C52F4C /* Pods-DataLayer.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -412,6 +514,7 @@
 		};
 		41BDFE2828CA164C00017768 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E6AC935ED0A6074A91D38FA6 /* Pods-DataLayerTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -431,6 +534,7 @@
 		};
 		41BDFE2928CA164C00017768 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DC0146D3161118FC38243A4C /* Pods-DataLayerTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";

--- a/DataLayer.xcworkspace/contents.xcworkspacedata
+++ b/DataLayer.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:DataLayer.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/DataLayer.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DataLayer.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,12 @@
+platform :ios, '13.0'
+
+target 'DataLayer' do
+  use_frameworks!
+
+  pod 'Alamofire', '~> 5.6.2'
+
+  target 'DataLayerTests' do
+    inherit! :search_paths
+  end
+
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Alamofire (5.6.2)
+
+DEPENDENCIES:
+  - Alamofire (~> 5.6.2)
+
+SPEC REPOS:
+  trunk:
+    - Alamofire
+
+SPEC CHECKSUMS:
+  Alamofire: d368e1ff8a298e6dde360e35a3e68e6c610e7204
+
+PODFILE CHECKSUM: 179514cddc20d65f0e94ab53d95adbe40de4dcf7
+
+COCOAPODS: 1.11.3


### PR DESCRIPTION
## Description
root 폴더에 CocoaPods를 초기화 후 주석 제거, 플랫폼을 명시하였습니다.

이후 본 프로젝트에  HTTP networking library로 사용할 Alamofire를 설치하였습니다.

## Notice
Podfile.lock의 경우 프로젝트 관리간 동일한 버전의 체크섬을 사용하기 위해 ignore 시키지 않았습니다.

플랫폼의 경우 pod install시 생기는 warning을 없애기 위해 추가하였고, iOS Deployment Target과 동일한 13.0을 사용하였습니다.

이 PR 이후로 DataLayer.xcodeproj 파일이 아닌 DataLayer.xcworkspace 파일을 사용하여 Xcode를 실행시켜야 합니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #5 