### PR TITLE
feat: add request result

### DIFF
--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		41BDFE0A28CA164C00017768 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 41BDFE0828CA164C00017768 /* LaunchScreen.storyboard */; };
 		41BDFE1528CA164C00017768 /* DataLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE1428CA164C00017768 /* DataLayerTests.swift */; };
 		41BDFE6B28CBF12400017768 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE6A28CBF12400017768 /* Routable.swift */; };
+		41BDFE6F28CCC75E00017768 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE6E28CCC75E00017768 /* Response.swift */; };
 		43191D82CA1EF59A6928AE46 /* Pods_DataLayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAFC0BFF785D8CB01827DF2D /* Pods_DataLayer.framework */; };
 		87D9684BF2F6FAA3DCB0E25D /* Pods_DataLayerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFB777B2EB545EBF1F9C23FF /* Pods_DataLayerTests.framework */; };
 /* End PBXBuildFile section */
@@ -42,6 +43,7 @@
 		41BDFE1028CA164C00017768 /* DataLayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DataLayerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFE1428CA164C00017768 /* DataLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataLayerTests.swift; sourceTree = "<group>"; };
 		41BDFE6A28CBF12400017768 /* Routable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
+		41BDFE6E28CCC75E00017768 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		DAFC0BFF785D8CB01827DF2D /* Pods_DataLayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DataLayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC0146D3161118FC38243A4C /* Pods-DataLayerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayerTests.release.xcconfig"; path = "Target Support Files/Pods-DataLayerTests/Pods-DataLayerTests.release.xcconfig"; sourceTree = "<group>"; };
 		E6AC935ED0A6074A91D38FA6 /* Pods-DataLayerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayerTests.debug.xcconfig"; path = "Target Support Files/Pods-DataLayerTests/Pods-DataLayerTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				41BDFE6A28CBF12400017768 /* Routable.swift */,
+				41BDFE6E28CCC75E00017768 /* Response.swift */,
 			);
 			path = Alamofire;
 			sourceTree = "<group>";
@@ -312,6 +315,7 @@
 				41BDFDFE28CA164B00017768 /* AppDelegate.swift in Sources */,
 				41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */,
 				41BDFE6B28CBF12400017768 /* Routable.swift in Sources */,
+				41BDFE6F28CCC75E00017768 /* Response.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DataLayer/Alamofire/Response.swift
+++ b/DataLayer/Alamofire/Response.swift
@@ -1,0 +1,26 @@
+//
+//  Response.swift
+//  DataLayer
+//
+//  Created by Jeongho Moon on 2022/09/10.
+//
+
+import Foundation
+
+typealias RequestResult<Success: Codable, Failure: Codable> =
+    Result<Response<Success, Failure>, Error>
+
+enum Response<Success: Codable, Failure: Codable>: Codable {
+    case success(Success)
+    case failure(Failure)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        do {
+            self = .success(try container.decode(Success.self))
+        } catch {
+            self = .failure(try container.decode(Failure.self))
+        }
+    }
+}


### PR DESCRIPTION
## Description
요청에 대한 응답을 처리하기 위해 RequestResult enum을 작성하였습니다.
요청 자체가 실패한 경우 나오는 에러를 처리하기 위해 Result 형태의 enum을 이용하였고,
이와 별개로 응답 자체의 성공, 실패를 처리하기위해 Response enum을 작성하였습니다.

## Notice
Response enum의 경우 성공과 실패에 대해 각각을 Codable 타입으로 제한한 제네릭 타입을 받습니다.
응답 처리 뿐만아니라 요청시 dto를 사용하는 경우를 생각해 Decodable이 아닌 Codable로 제한하였습니다

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #8 