### PR TITLE
feat: create network service

### DIFF
--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		41BDFE1528CA164C00017768 /* DataLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE1428CA164C00017768 /* DataLayerTests.swift */; };
 		41BDFE6B28CBF12400017768 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE6A28CBF12400017768 /* Routable.swift */; };
 		41BDFE6F28CCC75E00017768 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE6E28CCC75E00017768 /* Response.swift */; };
+		41BDFE7128CDBAD300017768 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE7028CDBAD300017768 /* NetworkService.swift */; };
 		43191D82CA1EF59A6928AE46 /* Pods_DataLayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAFC0BFF785D8CB01827DF2D /* Pods_DataLayer.framework */; };
 		87D9684BF2F6FAA3DCB0E25D /* Pods_DataLayerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFB777B2EB545EBF1F9C23FF /* Pods_DataLayerTests.framework */; };
 /* End PBXBuildFile section */
@@ -44,6 +45,7 @@
 		41BDFE1428CA164C00017768 /* DataLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataLayerTests.swift; sourceTree = "<group>"; };
 		41BDFE6A28CBF12400017768 /* Routable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
 		41BDFE6E28CCC75E00017768 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		41BDFE7028CDBAD300017768 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		DAFC0BFF785D8CB01827DF2D /* Pods_DataLayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DataLayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC0146D3161118FC38243A4C /* Pods-DataLayerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayerTests.release.xcconfig"; path = "Target Support Files/Pods-DataLayerTests/Pods-DataLayerTests.release.xcconfig"; sourceTree = "<group>"; };
 		E6AC935ED0A6074A91D38FA6 /* Pods-DataLayerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayerTests.debug.xcconfig"; path = "Target Support Files/Pods-DataLayerTests/Pods-DataLayerTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 		41BDFE6928CBF11900017768 /* Alamofire */ = {
 			isa = PBXGroup;
 			children = (
+				41BDFE7028CDBAD300017768 /* NetworkService.swift */,
 				41BDFE6A28CBF12400017768 /* Routable.swift */,
 				41BDFE6E28CCC75E00017768 /* Response.swift */,
 			);
@@ -315,6 +318,7 @@
 				41BDFDFE28CA164B00017768 /* AppDelegate.swift in Sources */,
 				41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */,
 				41BDFE6B28CBF12400017768 /* Routable.swift in Sources */,
+				41BDFE7128CDBAD300017768 /* NetworkService.swift in Sources */,
 				41BDFE6F28CCC75E00017768 /* Response.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DataLayer/Alamofire/NetworkService.swift
+++ b/DataLayer/Alamofire/NetworkService.swift
@@ -1,0 +1,46 @@
+//
+//  NetworkService.swift
+//  DataLayer
+//
+//  Created by Jeongho Moon on 2022/09/11.
+//
+
+import Alamofire
+
+protocol NetworkServiceable {
+    init(session: Session)
+
+    func request<Success: Codable, Failure: Codable>(
+        router: Routable,
+        completion: @escaping (RequestResult<Success, Failure>) -> Void
+    )
+}
+
+final class NetworkService: NetworkServiceable {
+    enum Error: Swift.Error, Equatable {
+        case parametersEncodingFailed
+    }
+
+    private let session: Session
+
+    required init(session: Session = Session.default) {
+        self.session = session
+    }
+
+    func request<Success: Codable, Failure: Codable>(
+        router: Routable,
+        completion: @escaping (RequestResult<Success, Failure>) -> Void
+    ) {
+        session.request(router).responseDecodable(
+            of: Response<Success, Failure>.self
+        ) { response in let result = response.result
+            switch result {
+            case let .success(data):
+                return completion(.success(data))
+            case let .failure(error):
+                return completion(.failure(error))
+            }
+        }
+    }
+}
+

--- a/DataLayer/Alamofire/Routable.swift
+++ b/DataLayer/Alamofire/Routable.swift
@@ -61,7 +61,7 @@ extension Routable {
                     """
                 )
 
-                throw NetworkServiceError.parametersEncodingFailed
+                throw NetworkService.Error.parametersEncodingFailed
             }
 
             request = try encoding.encode(request, with: parameters)
@@ -69,9 +69,4 @@ extension Routable {
 
         return request
     }
-}
-
-
-enum NetworkServiceError: Error, Equatable {
-    case parametersEncodingFailed
 }


### PR DESCRIPTION
## Description
request, upload 요청을 처리하는 NetworkService 클래스를 작성하였습니다.
### NetworkService
1. Alamofire의 Session 객체를 이용해 초기화합니다.
2. request, upload 메소드의 경우 Routable 프로토콜을 채택한 객체를 인자로 받아 요청을 수행합니다.
3. request와 upload의 공통 로직을 private 메소드로 분리한 performRequest를 작성하였습니다.
4. request와 upload의 차이는 request는 일반 HTTP 요청이지만, upload는 이미지, 미디어 등의 multipartFormData에 대한 요청입니다.
5. 응답의 경우 responseDecodable 메소드를 이용해 응답을 성공적으로 디코딩 했는지,
    에러가 났는지에 따라 경우를 나누고 completion handler를 호출하여 escaping 시킵니다.
### NetworkService.Error
1. Error의 경우 NetworkService 네임스페이스에 포함하여 해당 클래스를 통해 발생하는 에러를 구분합니다.
2. router에 multipartFormData가 nil인 경우, multipartRequestFailed 에러를 failure의 연관값으로 넣어 escape 시킵니다.

## Notice
### Test
1. Session 객체에 URLProtocol 설정을 넣어 테스트 할 수 있습니다. 관련 내용은 [WWDC 2018](https://developer.apple.com/videos/play/wwdc2018/417/)에서 참고할 수 있습니다.
2. NetworkServiceable 프로토콜을 사용하여 추상화된 인터페이스를 바탕으로 느슨한 결합을 유지하고,
    NetworkService 자체를 Mocking해서 사용하기 위해 분리하였습니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #11 