### PR TITLE
feat: create keychain service

### DIFF
--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4141BB5428CF7BD20085B6ED /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5328CF7BD20085B6ED /* Keychain.swift */; };
 		41BDFDFE28CA164B00017768 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFD28CA164B00017768 /* AppDelegate.swift */; };
 		41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFF28CA164B00017768 /* SceneDelegate.swift */; };
 		41BDFE0228CA164B00017768 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE0128CA164B00017768 /* ViewController.swift */; };
@@ -36,6 +37,7 @@
 
 /* Begin PBXFileReference section */
 		07A8E7444B5E1F8C2BF9FC4D /* Pods-DataLayer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayer.debug.xcconfig"; path = "Target Support Files/Pods-DataLayer/Pods-DataLayer.debug.xcconfig"; sourceTree = "<group>"; };
+		4141BB5328CF7BD20085B6ED /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		41BDFDFA28CA164B00017768 /* DataLayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DataLayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFDFD28CA164B00017768 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		41BDFDFF28CA164B00017768 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -79,6 +81,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4141BB5228CF78A90085B6ED /* Keychain */ = {
+			isa = PBXGroup;
+			children = (
+				4141BB5328CF7BD20085B6ED /* Keychain.swift */,
+			);
+			path = Keychain;
+			sourceTree = "<group>";
+		};
 		41BDFDF128CA164B00017768 = {
 			isa = PBXGroup;
 			children = (
@@ -103,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				41BDFE6928CBF11900017768 /* Alamofire */,
+				4141BB5228CF78A90085B6ED /* Keychain */,
 				41BDFDFD28CA164B00017768 /* AppDelegate.swift */,
 				41BDFDFF28CA164B00017768 /* SceneDelegate.swift */,
 				41BDFE0128CA164B00017768 /* ViewController.swift */,
@@ -337,6 +348,7 @@
 				41BDFE6B28CBF12400017768 /* Routable.swift in Sources */,
 				41BDFE7128CDBAD300017768 /* NetworkService.swift in Sources */,
 				41BDFE6F28CCC75E00017768 /* Response.swift in Sources */,
+				4141BB5428CF7BD20085B6ED /* Keychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4141BB5428CF7BD20085B6ED /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5328CF7BD20085B6ED /* Keychain.swift */; };
+		4141BB5828CF89C90085B6ED /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5728CF89C90085B6ED /* KeychainService.swift */; };
 		41BDFDFE28CA164B00017768 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFD28CA164B00017768 /* AppDelegate.swift */; };
 		41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFF28CA164B00017768 /* SceneDelegate.swift */; };
 		41BDFE0228CA164B00017768 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE0128CA164B00017768 /* ViewController.swift */; };
@@ -38,6 +39,7 @@
 /* Begin PBXFileReference section */
 		07A8E7444B5E1F8C2BF9FC4D /* Pods-DataLayer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayer.debug.xcconfig"; path = "Target Support Files/Pods-DataLayer/Pods-DataLayer.debug.xcconfig"; sourceTree = "<group>"; };
 		4141BB5328CF7BD20085B6ED /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		4141BB5728CF89C90085B6ED /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		41BDFDFA28CA164B00017768 /* DataLayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DataLayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFDFD28CA164B00017768 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		41BDFDFF28CA164B00017768 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				4141BB5328CF7BD20085B6ED /* Keychain.swift */,
+				4141BB5728CF89C90085B6ED /* KeychainService.swift */,
 			);
 			path = Keychain;
 			sourceTree = "<group>";
@@ -347,6 +350,7 @@
 				41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */,
 				41BDFE6B28CBF12400017768 /* Routable.swift in Sources */,
 				41BDFE7128CDBAD300017768 /* NetworkService.swift in Sources */,
+				4141BB5828CF89C90085B6ED /* KeychainService.swift in Sources */,
 				41BDFE6F28CCC75E00017768 /* Response.swift in Sources */,
 				4141BB5428CF7BD20085B6ED /* Keychain.swift in Sources */,
 			);

--- a/DataLayer/Keychain/Keychain.swift
+++ b/DataLayer/Keychain/Keychain.swift
@@ -37,7 +37,17 @@ enum KeychainItemClass {
 }
 
 final class Keychain: Keychainable {
-    var query: [String : Any] {
+    enum Error: Swift.Error, Equatable {
+        case notFound
+    
+        case unexpectedData
+
+        case duplicateItem
+
+        case unhandledError(status: OSStatus)
+    }
+
+    var query: [String: Any] {
         return [
             kSecClass as String: itemClass.value,
             kSecAttrService as String: service

--- a/DataLayer/Keychain/Keychain.swift
+++ b/DataLayer/Keychain/Keychain.swift
@@ -1,0 +1,63 @@
+//
+//  Keychain.swift
+//  DataLayer
+//
+//  Created by Jeongho Moon on 2022/09/12.
+//
+
+import Foundation
+
+protocol Keychainable {
+    var query: [String: Any] { get }
+
+    init(itemClass: KeychainItemClass)
+}
+
+enum KeychainItemClass {
+    case genericPassword
+    case internetPassword
+    case certificate
+    case key
+    case identity
+
+    var value: CFString {
+        switch self {
+        case .genericPassword:
+            return kSecClassGenericPassword
+        case .internetPassword:
+            return kSecClassInternetPassword
+        case .certificate:
+            return kSecClassCertificate
+        case .key:
+            return kSecClassKey
+        case .identity:
+            return kSecClassIdentity
+        }
+    }
+}
+
+final class Keychain: Keychainable {
+    var query: [String : Any] {
+        return [
+            kSecClass as String: itemClass.value,
+            kSecAttrService as String: service
+        ]
+    }
+
+    private let itemClass: KeychainItemClass
+    private let service: String
+
+    required init(itemClass: KeychainItemClass = .genericPassword) {
+        guard let service = Bundle.main.bundleIdentifier else {
+            fatalError(
+                """
+                    Faild to load bundle identifier,
+                    CFBundleIdentifier is not defined.
+                """
+            )
+        }
+
+        self.itemClass = itemClass
+        self.service = service
+    }
+}

--- a/DataLayer/Keychain/KeychainService.swift
+++ b/DataLayer/Keychain/KeychainService.swift
@@ -1,0 +1,133 @@
+//
+//  KeychainService.swift
+//  DataLayer
+//
+//  Created by Jeongho Moon on 2022/09/13.
+//
+
+import Foundation
+
+protocol KeychainServiceable {
+    init(keychain: Keychainable)
+
+    func create<Key: Hashable, Value: Codable>(
+        value: Value,
+        forKey key: Key
+    ) throws
+
+    func read<Key: Hashable, Value: Codable>(forKey key: Key) throws -> Value
+
+    func update<Key: Hashable, Value: Codable>(
+        value: Value,
+        forKey key: Key
+    ) throws
+
+    func delete<Key: Hashable>(forKey key: Key) throws
+}
+
+final class KeychainService: KeychainServiceable {
+    private let keychain: Keychainable
+
+    required init(keychain: Keychainable = Keychain()) {
+        self.keychain = keychain
+    }
+
+    func create<Key: Hashable, Value: Codable>(
+        value: Value,
+        forKey key: Key
+    ) throws {
+        do {
+            let data = try JSONEncoder().encode(value)
+
+            var query = keychain.query
+            query[kSecAttrAccount as String] = key
+            query[kSecValueData as String] = data
+
+            let status = SecItemAdd(query as CFDictionary, nil)
+
+            try checkSecItem(status)
+        } catch {
+            throw error
+        }
+    }
+
+    func read<Key: Hashable, Value: Codable>(forKey key: Key) throws -> Value {
+        var query = keychain.query
+        query[kSecAttrAccount as String] = key
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnAttributes as String] = true
+        query[kSecReturnData as String] = true
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        try checkSecItem(status)
+
+        guard
+            let existingItem = item as? [CFString: Any],
+            let data = existingItem[kSecValueData] as? Data
+        else {
+            throw Keychain.Error.unexpectedData
+        }
+
+        do {
+            let value = try JSONDecoder().decode(Value.self, from: data)
+            return value
+        } catch {
+            throw error
+        }
+    }
+
+    func update<Key: Hashable, Value: Codable>(
+        value: Value,
+        forKey key: Key
+    ) throws {
+        do {
+            let data = try JSONEncoder().encode(value)
+
+            var query = keychain.query
+            query[kSecAttrAccount as String] = key
+
+            let attributes: [String: Any] = [
+                kSecAttrAccount as String: key,
+                kSecValueData as String: data
+            ]
+
+            let status = SecItemUpdate(
+                query as CFDictionary,
+                attributes as CFDictionary
+            )
+
+            try checkSecItem(status)
+        } catch {
+            throw error
+        }
+    }
+
+    func delete<Key: Hashable>(forKey key: Key) throws {
+        do {
+            var query = keychain.query
+            query[kSecAttrAccount as String] = key
+
+            let status = SecItemDelete(query as CFDictionary)
+
+            try checkSecItem(status)
+        } catch {
+            throw error
+        }
+    }
+
+    private func checkSecItem(_ status: OSStatus) throws {
+        guard status != errSecDuplicateItem else {
+            throw Keychain.Error.duplicateItem
+        }
+
+        guard status != errSecItemNotFound else {
+            throw Keychain.Error.notFound
+        }
+
+        guard status == errSecSuccess else {
+            throw Keychain.Error.unhandledError(status: status)
+        }
+    }
+}


### PR DESCRIPTION
## Description
### Keychain
- KeychainItem 열거형을 사용하여 Keychain Item Class를 지정 할 수 있도록 하였습니다.
- kSecClass와 kSecAttrService를 Dictionary 형태로 만든 query 프로퍼티를 사용하여 crud 연산에서 코드 중복을 줄였습니다.
- query에 들어가는 value들은 Kechain 클래스의 init에서 초기화되고,
   service 값으로 사용되는 bundleIdentifier의 언레핑 과정 실패시 fatalError로 앱을 정지시킵니다.
- KeychainService에서 일어나는 Error들은 Keychain 클래스의 네임스페이스 안에 추가하였습니다.
### KeychainService
[애플 개발자 문서](https://developer.apple.com/documentation/security/keychain_services/keychain_items/adding_a_password_to_the_keychain)를 참고하여 Keychain에 대한 CRUD 연산을 구현하였습니다.
- kSecClass와 kSecAttrService가 동일한 경우, 각 연산은 제네릭한 Key와 필요한 경우 Value 값을 인자로 받아 해당 연산을 수행합니다.
- Keychain CRUD 작성 시 중복되는 에러 throw 로직을 checkSecItem이라는 private 메소드를 이용하여 분리하였습니다.

## Notice
### Keychain
- Keychain을 init할때 KeychainItemClass의 기본값은 일반적으로 토큰, 패스워드에 많이 사용되는 genericPassword를 적용하였습니다.
- Keychain init 과정의 fatalError에 대해서 assert 구문으로 앱을 정지 시키지 않고 개발자에게 알리는 경우도 고려해보았지만
   CFBundleIdentifier가 정의되지 않은 경우 예기치 못한 사이드 이펙트가 발생할 수 있기 때문에 fatalError를 사용하였습니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #15 