### PR TITLE
perf: mark anyobject to class-only protocol

### DIFF
--- a/DataLayer/Alamofire/NetworkService.swift
+++ b/DataLayer/Alamofire/NetworkService.swift
@@ -7,7 +7,7 @@
 
 import Alamofire
 
-protocol NetworkServiceable {
+protocol NetworkServiceable: AnyObject {
     init(session: Session)
 
     func request<Success: Codable, Failure: Codable>(

--- a/DataLayer/Keychain/Keychain.swift
+++ b/DataLayer/Keychain/Keychain.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol Keychainable {
+protocol Keychainable: AnyObject {
     var query: [String: Any] { get }
 
     init(itemClass: KeychainItemClass)

--- a/DataLayer/Keychain/KeychainService.swift
+++ b/DataLayer/Keychain/KeychainService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol KeychainServiceable {
+protocol KeychainServiceable: AnyObject {
     init(keychain: Keychainable)
 
     func create<Key: Hashable, Value: Codable>(


### PR DESCRIPTION
## Description
### AnyObject
- 런타임 성능을 향상시키기 위해 클래스만이 채택하는 프로토콜에 대해 AnyObject를 명시합니다.
- 예를 들어, ARC 메모리 관리 시스템은 클래스를 처리한다는 것을 알고 있다면 쉽게 유지할 수 있습니다.
- 이 정보가 없다면, 컴파일러는 구조체가 프로토콜을 채택할 경우를 대비해 할당과 해제를할 준비를 해야하므로 비용이 많이들 수 있습니다.

## Notice
### OptimizationTips
- Swift 깃허브 문서의 성능 최적화 팁 중에 [해당 단락](https://github.com/apple/swift/blob/main/docs/OptimizationTips.rst#advice-mark-protocols-that-are-only-satisfied-by-classes-as-class-protocols) 을 참고하여 작업을 진행하였습니다.
- AnyObject 팁 외에도 다이나믹 디스패치를 제한하여 성능을 향상 시키는 접근 지정자,
   클래스 final 등은 쉽게 할 수 있는 작업이기 때문에 매 작업마다 까먹지 말고 진행하도록 합니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #17 