### PR TITLE
feat: add status code in response

### DIFF
--- a/DataLayer/Alamofire/Response.swift
+++ b/DataLayer/Alamofire/Response.swift
@@ -7,10 +7,13 @@
 
 import Foundation
 
-typealias RequestResult<Success: Codable, Failure: Codable> =
+typealias ResponseResult<Success: Codable, Failure: Codable> =
     Result<Response<Success, Failure>, Error>
 
-enum Response<Success: Codable, Failure: Codable>: Codable {
+typealias Response<Success: Codable, Failure: Codable> =
+    (statusCode: Int, body: Body<Success, Failure>)
+
+enum Body<Success: Codable, Failure: Codable>: Codable {
     case success(Success)
     case failure(Failure)
 


### PR DESCRIPTION
## Description
### Response
요청에 대한 응답으로 받는 타입들의 네이밍을 변경하였습니다.
- Response -> Body
- RequestResult -> ResponseResult
### statusCode
- 상태 코드가 포함된 결과를 받기위해 statusCode와 body를 묶은 Response 타입을 만들고
   ResponseResult에 성공 케이스의 연관값으로 타입을 지정하였습니다.
### invalidHTTPURLResponse Error
- 응답에서 statusCode가 없는 경우에 대한 에러를 던지기 위해
   statusCode에 대한 언레핑과정에 invalidHTTPURLResponse에러를 추가하였습니다.

## Notice
### NetworkServiceTests
- 응답 인터페이스가 변경되었기 때문에 테스트 코드도 마찬가지로 수정되어야 합니다.
- invalidHTTPURLResponse 에러에 대한 테스트도 추가되어야 합니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #20 