### PR TITLE
test: edit network service test

### DIFF
--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4141BB5428CF7BD20085B6ED /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5328CF7BD20085B6ED /* Keychain.swift */; };
 		4141BB5828CF89C90085B6ED /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5728CF89C90085B6ED /* KeychainService.swift */; };
+		4141BB5F28D615350085B6ED /* EmptyRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5E28D615350085B6ED /* EmptyRouter.swift */; };
 		41BDFDFE28CA164B00017768 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFD28CA164B00017768 /* AppDelegate.swift */; };
 		41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFF28CA164B00017768 /* SceneDelegate.swift */; };
 		41BDFE0228CA164B00017768 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE0128CA164B00017768 /* ViewController.swift */; };
@@ -40,6 +41,7 @@
 		07A8E7444B5E1F8C2BF9FC4D /* Pods-DataLayer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DataLayer.debug.xcconfig"; path = "Target Support Files/Pods-DataLayer/Pods-DataLayer.debug.xcconfig"; sourceTree = "<group>"; };
 		4141BB5328CF7BD20085B6ED /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		4141BB5728CF89C90085B6ED /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		4141BB5E28D615350085B6ED /* EmptyRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyRouter.swift; sourceTree = "<group>"; };
 		41BDFDFA28CA164B00017768 /* DataLayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DataLayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFDFD28CA164B00017768 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		41BDFDFF28CA164B00017768 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 			children = (
 				41BDFE7928CDFC9C00017768 /* NetworkServiceTests.swift */,
 				41BDFE7728CDFC8500017768 /* TestRouter.swift */,
+				4141BB5E28D615350085B6ED /* EmptyRouter.swift */,
 				41BDFE7528CDCD3F00017768 /* NetworkService+.swift */,
 				41BDFE7328CDCCD500017768 /* MockURLProtocol.swift */,
 			);
@@ -364,6 +367,7 @@
 				41BDFE7428CDCCD500017768 /* MockURLProtocol.swift in Sources */,
 				41BDFE7A28CDFC9C00017768 /* NetworkServiceTests.swift in Sources */,
 				41BDFE7828CDFC8500017768 /* TestRouter.swift in Sources */,
+				4141BB5F28D615350085B6ED /* EmptyRouter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DataLayerTests/Alamofire/EmptyRouter.swift
+++ b/DataLayerTests/Alamofire/EmptyRouter.swift
@@ -1,0 +1,22 @@
+//
+//  EmptyRouter.swift
+//  DataLayerTests
+//
+//  Created by Jeongho Moon on 2022/09/17.
+//
+
+import Alamofire
+@testable import DataLayer
+
+enum EmptyRouter: Routable {
+    case emptyEncoding
+    case emptyMultipartFormData
+
+    var method: HTTPMethod {
+        return .post
+    }
+
+    var path: String {
+        return ""
+    }
+}

--- a/DataLayerTests/Alamofire/MockURLProtocol.swift
+++ b/DataLayerTests/Alamofire/MockURLProtocol.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class MockURLProtocol: URLProtocol {
     static var requestHandler: (
-        (URLRequest) throws -> (HTTPURLResponse, Data)
+        (URLRequest) throws -> (URLResponse, Data)
     )?
 
     override class func canInit(with request: URLRequest) -> Bool {

--- a/DataLayerTests/Alamofire/NetworkServiceTests.swift
+++ b/DataLayerTests/Alamofire/NetworkServiceTests.swift
@@ -41,41 +41,47 @@ class NetworkServiceTests: XCTestCase {
     }
 
     func testValidRequestSuccess() {
-        requestSuccess(router: .validRequest, request: sut.request)
+        requestSuccess(router: TestRouter.validRequest, request: sut.request)
     }
 
     func testInvalidRequestFailure() {
-        requestFailure(router: .validRequest, request: sut.request)
+        requestFailure(router: TestRouter.validRequest, request: sut.request)
     }
 
     func testValidEncodingRequestSuccess() {
-        requestSuccess(router: .validEncodingRequest, request: sut.request)
+        requestSuccess(
+            router: TestRouter.validEncodingRequest,
+            request: sut.request
+        )
     }
 
     func testValidEncodingRequestFailure() {
-        requestFailure(router: .validEncodingRequest, request: sut.request)
+        requestFailure(
+            router: TestRouter.validEncodingRequest,
+            request: sut.request
+        )
     }
 
     func testInvalidEncodingRequestError() {
         requestError(
             .parametersEncodingFailed,
-            router: .invalidEncodingRequest,
+            router: TestRouter.invalidEncodingRequest,
             request: sut.request
         )
     }
 
     func testValidUploadSuccess() {
-        requestSuccess(router: .validUpload, request: sut.upload)
+        requestSuccess(router: TestRouter.validUpload, request: sut.upload)
     }
 
     func testValidUploadFailure() {
-        requestFailure(router: .validUpload, request: sut.upload)
+        requestFailure(router: TestRouter.validUpload, request: sut.upload)
     }
 
     func testInvalidUploadError() {
         requestError(
             .multipartRequestFailed,
-            router: .invalidUpload,
+            router: TestRouter.invalidUpload,
             request: sut.upload
         )
     }
@@ -83,12 +89,26 @@ class NetworkServiceTests: XCTestCase {
     func testInvalidHTTPURLResponseError() {
         requestError(
             .invalidHTTPURLResponse,
-            router: .validRequest,
+            router: TestRouter.validRequest,
             request: sut.request
         )
     }
 
-    private func requestSuccess(router: TestRouter, request: TestRequest) {
+    func testEmptyEncodingResponse() {
+        requestSuccess(router: EmptyRouter.emptyEncoding, request: sut.request)
+
+        requestFailure(router: EmptyRouter.emptyEncoding, request: sut.request)
+    }
+
+    func testEmptyMultipartFormDataResponseError() {
+        requestError(
+            .multipartRequestFailed,
+            router: EmptyRouter.emptyMultipartFormData,
+            request: sut.upload
+        )
+    }
+
+    private func requestSuccess(router: Routable, request: TestRequest) {
         let expect = "bar"
 
         initSuccess(with: expect)
@@ -112,7 +132,7 @@ class NetworkServiceTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    private func requestFailure(router: TestRouter, request: TestRequest) {
+    private func requestFailure(router: Routable, request: TestRequest) {
         let expect = "qux"
 
         initFailure(with: expect)
@@ -138,7 +158,7 @@ class NetworkServiceTests: XCTestCase {
 
     private func requestError(
         _ expectedError: NetworkService.Error,
-        router: TestRouter,
+        router: Routable,
         request: TestRequest
     ) {
         let expect = "bar"


### PR DESCRIPTION
## Description

### MockURLProtocol
- invalidHTTPURLResponse에 대한 테스트 코드를 작성하기 위해 MockURLProtocol의
- requestHandler 클로저의 반환 값을 URLResponse로 수정하였습니다

### NetworkServiceTests
- 변경된 응답 인터페이스에 맞추어 response에서 바디를 체이닝하도록 수정하였습니다.
- success, failure 케이스에서 statusCode를 테스트하는 로직을 추가하였습니다.
- invalidHTTPURLResponse에 대한 테스트 코드를 작성하였습니다.
- encoding이 없는 경우 오청시 생기는 성공, 실패에 대해 테스트 코드를 작성하였습니다.
- multipartFormData가 없는 경우 업로드 요청시 생기는 에러에 대해 테스트 코드를 작성하였습니다.

### EmptyRouter
- Routable 프로토콜에서 encoding과 multipartFormData가 없는 경우를 테스트 하기 위해 추가하였습니다.

## Notice
### testEmptyEncodingResponse, testEmptyMultipartFormDataResponseError
- encoding과 multipartFormData가 없는 경우를 성공, 실패, 에러 각각의 테스트에 넣으면
   혼동할 여지가 있다고 생각했기 때문에 각 경우에 대한 테스트를 따로 작성하였습니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #22 