### PR TITLE
test: add keychain service test

### DIFF
--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		4141BB5428CF7BD20085B6ED /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5328CF7BD20085B6ED /* Keychain.swift */; };
 		4141BB5828CF89C90085B6ED /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5728CF89C90085B6ED /* KeychainService.swift */; };
 		4141BB5F28D615350085B6ED /* EmptyRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4141BB5E28D615350085B6ED /* EmptyRouter.swift */; };
+		4153575128D8B07F00FBC80A /* Keychain+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153575028D8B07F00FBC80A /* Keychain+.swift */; };
+		4153575328D8B0AE00FBC80A /* KeychainService+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153575228D8B0AE00FBC80A /* KeychainService+.swift */; };
+		4153575728D8B0FF00FBC80A /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153575628D8B0FF00FBC80A /* KeychainServiceTests.swift */; };
 		41BDFDFE28CA164B00017768 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFD28CA164B00017768 /* AppDelegate.swift */; };
 		41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFF28CA164B00017768 /* SceneDelegate.swift */; };
 		41BDFE0228CA164B00017768 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE0128CA164B00017768 /* ViewController.swift */; };
@@ -42,6 +45,9 @@
 		4141BB5328CF7BD20085B6ED /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		4141BB5728CF89C90085B6ED /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		4141BB5E28D615350085B6ED /* EmptyRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyRouter.swift; sourceTree = "<group>"; };
+		4153575028D8B07F00FBC80A /* Keychain+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain+.swift"; sourceTree = "<group>"; };
+		4153575228D8B0AE00FBC80A /* KeychainService+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeychainService+.swift"; sourceTree = "<group>"; };
+		4153575628D8B0FF00FBC80A /* KeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceTests.swift; sourceTree = "<group>"; };
 		41BDFDFA28CA164B00017768 /* DataLayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DataLayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFDFD28CA164B00017768 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		41BDFDFF28CA164B00017768 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -94,6 +100,16 @@
 			path = Keychain;
 			sourceTree = "<group>";
 		};
+		4153574F28D8B07200FBC80A /* Keychain */ = {
+			isa = PBXGroup;
+			children = (
+				4153575628D8B0FF00FBC80A /* KeychainServiceTests.swift */,
+				4153575228D8B0AE00FBC80A /* KeychainService+.swift */,
+				4153575028D8B07F00FBC80A /* Keychain+.swift */,
+			);
+			path = Keychain;
+			sourceTree = "<group>";
+		};
 		41BDFDF128CA164B00017768 = {
 			isa = PBXGroup;
 			children = (
@@ -134,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				41BDFE7228CDCCAB00017768 /* Alamofire */,
+				4153574F28D8B07200FBC80A /* Keychain */,
 			);
 			path = DataLayerTests;
 			sourceTree = "<group>";
@@ -363,9 +380,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4153575328D8B0AE00FBC80A /* KeychainService+.swift in Sources */,
 				41BDFE7628CDCD3F00017768 /* NetworkService+.swift in Sources */,
+				4153575128D8B07F00FBC80A /* Keychain+.swift in Sources */,
 				41BDFE7428CDCCD500017768 /* MockURLProtocol.swift in Sources */,
 				41BDFE7A28CDFC9C00017768 /* NetworkServiceTests.swift in Sources */,
+				4153575728D8B0FF00FBC80A /* KeychainServiceTests.swift in Sources */,
 				41BDFE7828CDFC8500017768 /* TestRouter.swift in Sources */,
 				4141BB5F28D615350085B6ED /* EmptyRouter.swift in Sources */,
 			);

--- a/DataLayerTests/Keychain/Keychain+.swift
+++ b/DataLayerTests/Keychain/Keychain+.swift
@@ -1,0 +1,17 @@
+//
+//  Keychain+.swift
+//  DataLayerTests
+//
+//  Created by Jeongho Moon on 2022/09/19.
+//
+
+import Foundation
+@testable import DataLayer
+
+extension Keychain {
+    convenience init() {
+        self.init(service: "")
+
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/DataLayerTests/Keychain/KeychainService+.swift
+++ b/DataLayerTests/Keychain/KeychainService+.swift
@@ -1,0 +1,15 @@
+//
+//  KeychainService+.swift
+//  DataLayerTests
+//
+//  Created by Jeongho Moon on 2022/09/19.
+//
+
+import Foundation
+@testable import DataLayer
+
+extension KeychainService {
+    convenience init() {
+        self.init(keychain: Keychain())
+    }
+}

--- a/DataLayerTests/Keychain/KeychainServiceTests.swift
+++ b/DataLayerTests/Keychain/KeychainServiceTests.swift
@@ -1,0 +1,124 @@
+//
+//  KeychainServiceTests.swift
+//  DataLayerTests
+//
+//  Created by Jeongho Moon on 2022/09/19.
+//
+
+import Foundation
+import XCTest
+@testable import DataLayer
+
+class KeychainServiceTests: XCTestCase {
+    var sut: KeychainServiceable!
+
+    private let key = "key",
+                valueForCreate = "create",
+                valueForUpdate = "update"
+
+    override func setUp() {
+        super.setUp()
+
+        sut = KeychainService()
+    }
+
+    override func tearDown() {
+        sut = nil
+    }
+
+    func testCreateSuccess() {
+        expressNoError(try self.createKeychainItem())
+    }
+
+    func testCreateErrorDuplicateItem() {
+        expressNoError(try self.createKeychainItem())
+
+        expressError(try self.createKeychainItem(), expected: .duplicateItem)
+    }
+
+    func testReadSuccess() {
+        expressNoError(try self.createKeychainItem())
+
+        expressNoError(try self.readKeychainItem(expected: valueForCreate))
+    }
+
+    func testReadErrorNotFound() {
+        expressError(
+            try self.readKeychainItem(expected: valueForUpdate),
+            expected: .notFound
+        )
+    }
+
+    func testUpdateSuccess() {
+        expressNoError(try self.createKeychainItem())
+
+        expressNoError(try self.updateKeychainItem())
+    }
+
+    func testUpdateErrorNotFound() {
+        expressError(try self.updateKeychainItem(), expected: .notFound)
+    }
+
+    func testDeleteSuccess() {
+        expressNoError(try self.createKeychainItem())
+
+        expressNoError(try self.deleteKeychainItem())
+    }
+
+    func testDeleteErrorNotFound() {
+        expressError(try self.deleteKeychainItem(), expected: .notFound)
+    }
+
+    private func expressError(
+        _ expression: @autoclosure () throws -> Void,
+        expected expect: KeychainService.Error
+    ) {
+        XCTAssertThrowsError(
+            try expression()
+        ) { error in let error = error as? KeychainService.Error
+            XCTAssertEqual(error, expect)
+        }
+    }
+
+    private func expressNoError(
+        _ expression: @autoclosure () throws -> Void
+    ) {
+        XCTAssertNoThrow(try expression())
+    }
+
+    private func createKeychainItem() throws {
+        do {
+            try sut.create(valueForCreate, forKey: key)
+        } catch {
+            throw error
+        }
+    }
+
+    private func readKeychainItem(expected expect: String?) throws {
+        do {
+            let value: String = try sut.read(forKey: key)
+
+            guard let expect = expect else { return }
+
+            XCTAssertEqual(value, expect)
+        } catch {
+            throw error
+        }
+    }
+
+    private func updateKeychainItem() throws {
+        do {
+            try sut.update(valueForUpdate, forKey: key)
+        } catch {
+            throw error
+        }
+    }
+
+    private func deleteKeychainItem() throws {
+        do {
+            try sut.delete(forKey: key)
+        } catch {
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Description

### Keychain+
- 테스트시 실제 번들 값이 아닌 empty string을 서비스 값으로 주입하여 초기화하는 convenience initializer를 작성하였습니다.
- 추가로, 매 테스트마다 저장된 값을 초기화하기 위해 init 이후에 query에 해당하는 값을 삭제하는 로직을 추가하였습니다.

### KeychainService+
- 테스트시, Keychain의 테스트 코드를 위한 initializer를 사용하기 위해 이를 초기화 하는 convenience initializer를 작성하였습니다.

### KeychainServiceTests
- Keychain 각각의 CRUD와 각 동작에 대해 예상되는 에러를 테스트 하는 메소드를 작성하였습니다.
- create의 경우 duplicatedItem, read, update, delete의 경우 notFound 에러를 테스트하도록 하였습니다.

## Notice

### TestCoverage
- 타입 제한, plist 설정, 핸들링하기에 오버 엔지니어링 급의 에러들 테스트 제외하였습니다.
  1. bundleIdentifier가 없는 경우
  2. 인코딩&디코딩 실패에 대한 경우
  3. unhandledError의 경우
- unexpectedData에러의 경우 테스트 효용성을 검토하여 이후 추가할 수 있도록 고려해보겠습니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #19 