### PR TITLE
feat: create user defaults service

### DIFF
--- a/DataLayer.xcodeproj/project.pbxproj
+++ b/DataLayer.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4153575128D8B07F00FBC80A /* Keychain+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153575028D8B07F00FBC80A /* Keychain+.swift */; };
 		4153575328D8B0AE00FBC80A /* KeychainService+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153575228D8B0AE00FBC80A /* KeychainService+.swift */; };
 		4153575728D8B0FF00FBC80A /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153575628D8B0FF00FBC80A /* KeychainServiceTests.swift */; };
+		4166A2B428DC83C90066D335 /* UserDefaultsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4166A2B328DC83C90066D335 /* UserDefaultsService.swift */; };
 		41BDFDFE28CA164B00017768 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFD28CA164B00017768 /* AppDelegate.swift */; };
 		41BDFE0028CA164B00017768 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFDFF28CA164B00017768 /* SceneDelegate.swift */; };
 		41BDFE0228CA164B00017768 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BDFE0128CA164B00017768 /* ViewController.swift */; };
@@ -48,6 +49,7 @@
 		4153575028D8B07F00FBC80A /* Keychain+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain+.swift"; sourceTree = "<group>"; };
 		4153575228D8B0AE00FBC80A /* KeychainService+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeychainService+.swift"; sourceTree = "<group>"; };
 		4153575628D8B0FF00FBC80A /* KeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceTests.swift; sourceTree = "<group>"; };
+		4166A2B328DC83C90066D335 /* UserDefaultsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsService.swift; sourceTree = "<group>"; };
 		41BDFDFA28CA164B00017768 /* DataLayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DataLayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41BDFDFD28CA164B00017768 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		41BDFDFF28CA164B00017768 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +112,14 @@
 			path = Keychain;
 			sourceTree = "<group>";
 		};
+		4166A2B228DC839C0066D335 /* UserDefaults */ = {
+			isa = PBXGroup;
+			children = (
+				4166A2B328DC83C90066D335 /* UserDefaultsService.swift */,
+			);
+			path = UserDefaults;
+			sourceTree = "<group>";
+		};
 		41BDFDF128CA164B00017768 = {
 			isa = PBXGroup;
 			children = (
@@ -135,6 +145,7 @@
 			children = (
 				41BDFE6928CBF11900017768 /* Alamofire */,
 				4141BB5228CF78A90085B6ED /* Keychain */,
+				4166A2B228DC839C0066D335 /* UserDefaults */,
 				41BDFDFD28CA164B00017768 /* AppDelegate.swift */,
 				41BDFDFF28CA164B00017768 /* SceneDelegate.swift */,
 				41BDFE0128CA164B00017768 /* ViewController.swift */,
@@ -371,6 +382,7 @@
 				41BDFE6B28CBF12400017768 /* Routable.swift in Sources */,
 				41BDFE7128CDBAD300017768 /* NetworkService.swift in Sources */,
 				4141BB5828CF89C90085B6ED /* KeychainService.swift in Sources */,
+				4166A2B428DC83C90066D335 /* UserDefaultsService.swift in Sources */,
 				41BDFE6F28CCC75E00017768 /* Response.swift in Sources */,
 				4141BB5428CF7BD20085B6ED /* Keychain.swift in Sources */,
 			);

--- a/DataLayer/UserDefaults/UserDefaultsService.swift
+++ b/DataLayer/UserDefaults/UserDefaultsService.swift
@@ -1,0 +1,93 @@
+//
+//  UserDefaultsService.swift
+//  DataLayer
+//
+//  Created by Jeongho Moon on 2022/09/22.
+//
+
+import Foundation
+
+protocol UserDefaultsServiceable: AnyObject {
+    init(identifier: String?)
+
+    func create<Value: Codable>(_ value: Value, forKey key: String) throws
+
+    func read<Value: Codable>(forKey key: String) throws -> Value
+
+    func update<Value: Codable>(_ value: Value, forKey key: String) throws
+
+    func delete(forKey key: String) throws
+}
+
+final class UserDefaultsService: UserDefaultsServiceable {
+    enum Error: Swift.Error, Equatable {
+        case notFound
+
+        case unexpectedData
+
+        case duplicateItem
+    }
+
+    let userDefaults: UserDefaults
+
+    required init(identifier: String? = nil) {
+        let suiteName: String?
+
+        if let identifier = identifier {
+            suiteName = identifier
+        } else {
+            suiteName = Bundle.main.bundleIdentifier
+        }
+
+        guard let suiteName = suiteName,
+              let userDefaults = UserDefaults(suiteName: suiteName)
+        else {
+            fatalError("Failed to init store. Bundle Identifier isn't defined.")
+        }
+
+        self.userDefaults = userDefaults
+    }
+
+    func create<Value: Codable>(_ value: Value, forKey key: String) throws {
+        do {
+            try findObject(forKey: key)
+
+            throw UserDefaultsService.Error.duplicateItem
+        } catch UserDefaultsService.Error.notFound {
+            let data = try JSONEncoder().encode(value)
+
+            userDefaults.set(data, forKey: key)
+        }
+    }
+
+    func read<Value: Codable>(forKey key: String) throws -> Value {
+        guard let data = try findObject(forKey: key) as? Data else {
+            throw UserDefaultsService.Error.unexpectedData
+        }
+
+        return try JSONDecoder().decode(Value.self, from: data)
+    }
+
+    func update<Value: Codable>(_ value: Value, forKey key: String) throws {
+        let data = try JSONEncoder().encode(value)
+
+        try findObject(forKey: key)
+
+        userDefaults.set(data, forKey: key)
+    }
+
+    func delete(forKey key: String) throws {
+        try findObject(forKey: key)
+
+        userDefaults.removeObject(forKey: key)
+    }
+
+    @discardableResult
+    private func findObject(forKey key: String) throws -> Any {
+        guard let object = userDefaults.object(forKey: key) else {
+            throw UserDefaultsService.Error.notFound
+        }
+
+        return object
+    }
+}


### PR DESCRIPTION
## Description
### UserDefaultsService
- identifier를 주입받아 테스트 환경과 실제 환경을 구별하기 위한 initializer 추가
- UserDefaults에 대한 CRUD 메소드 작성
- CRUD 이전에 데이터 유무를 확인하는 findObject 메소드 추가

## Notice
### KeychainService + UserDefaultsService
- UserDefaultsServices 클래스는 KeychainService 클래스와 인터페이스, 에러 타입이 유사하고,
   Keychain 클래스도 UserDefaults의 suiteName과 유사하게 service 값을 가지고 초기화하기 때문에
   향후 두 클래스를 저장소 타입을 선택하여 Key-Value 쌍으로 저장할 수 있는 클래스로 합치는걸 고려중입니다.

## Environment
macOS: Monterey 12.5.1, Apple M1
iOS: 15.5, iPhone 13 mini
IDE: Xcode 13.4.1

Resolves: #27 